### PR TITLE
Swapping start and restart of service in restart command

### DIFF
--- a/lib/capistrano/tasks/foreman.cap
+++ b/lib/capistrano/tasks/foreman.cap
@@ -35,7 +35,7 @@ namespace :foreman do
   task :restart do
     on roles(:app) do |host|
       as :root do
-        execute :service, "#{fetch(:application)} start || service #{fetch(:application)} restart"
+        execute :service, "#{fetch(:application)} restart || service #{fetch(:application)} start"
       end
     end
   end


### PR DESCRIPTION
I was getting a bit annoyed by the warnings I saw every time I deployed. It turns out by default the `foreman:restart` was trying a `start` first before trying an actual `restart`. I changed the order to a `restart` and then a `start` if the server isnt running. Seems better to me but I might be wrong.